### PR TITLE
Preserve intended redirect with specific homepage set

### DIFF
--- a/app/Access/Controllers/LoginController.php
+++ b/app/Access/Controllers/LoginController.php
@@ -137,7 +137,7 @@ class LoginController extends Controller
         $request->session()->regenerate();
         $this->clearLoginAttempts($request);
 
-        return redirect()->intended('/');
+        return redirect()->intended();
     }
 
     /**


### PR DESCRIPTION
The specific homepage setting that was added recently added a bit more friction to navigating to pages from a logged out state. The LoginController was overriding the intended with the base path `'/'`. With the homepage set, the intended route does not make it through the HomeController. Adella brought it up to me, because safety staff often navigate to reports from their phone or email in a logged out state.

All auth middleware still works as expected. So if a user attempts to log in to a path they have no view auth for directly, they'll be redirected to the home page as expected. We don't have many of those pages right now anyway. Not sure of the reasoning of pre-filling the intended route in BookStack.

Do you have any concerns about this change?